### PR TITLE
fix for `Brackets Dark` theme

### DIFF
--- a/styles/newline.css
+++ b/styles/newline.css
@@ -26,3 +26,7 @@
     color: #333;
     cursor: pointer;
 }
+
+.dark #status-newline {
+    color: #cccccc;
+}


### PR DESCRIPTION
fixes https://github.com/LonelyStorm/brackets-newline/issues/1

currently it looks like this:
![image](https://cloud.githubusercontent.com/assets/1067319/15240211/631d4996-192b-11e6-8bb8-fee2380f2560.png)

after fix:
![image](https://cloud.githubusercontent.com/assets/1067319/15240226/83b49f7e-192b-11e6-9143-46a4cb2a8a9b.png)

